### PR TITLE
Workaround for Staticman bug

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -29,7 +29,7 @@ masthead_title           : # overrides the website title displayed in the masthe
 # breadcrumbs            : false # true, false (default)
 words_per_minute         : 200
 comments:
-  provider               : # "staticman_v2" # false (default), "disqus", "discourse", "facebook", "staticman", "staticman_v2", "utterances", "custom"
+  provider               : "staticman_v2" # false (default), "disqus", "discourse", "facebook", "staticman", "staticman_v2", "utterances", "custom"
   disqus:
     shortname            : # https://help.disqus.com/customer/portal/articles/466208-what-s-a-shortname-
   discourse:
@@ -58,7 +58,7 @@ staticman:
       type               : # "date"
       options:
         format           : # "iso8601" (default), "timestamp-seconds", "timestamp-milliseconds"
-  endpoint               : https://api.staticman.net/v3/entry/github/ # URL of your own deployment with trailing slash, will fallback to the public instance
+  endpoint               : https://staticman3.herokuapp.com/v3/entry/github/ # URL of your own deployment with trailing slash, will fallback to the public instance
 reCaptcha:
   siteKey                : "6Lcn16YUAAAAAHQ0gYkul1ffk5SRRae773Fp07TR" # "6LdRBykTAAAAAFB46MnIu6ixuxwu9W1ihFF8G60Q"
   secret                 : "yY2frR6l1UympRnrJqj5ZqNRHgnlETZzzOgqiFbJCH/n/Zflmg+T4iFw2RpbeBkSzPt7CXVG9f8A9jnTFuBhYpHPBGGRg/aPa48jOTkXpYtiyeVerTlctTjTPe92+eJbEId/JO4NiCan6bxGK/2+TqTuner0uHRw6fnVm1++Cxk=" # "PznnZGu3P6eTHRPLORniSq+J61YEf+A9zmColXDM5icqF49gbunH51B8+h+i2IvewpuxtA9TFoK68TuhUp/X3YKmmqhXasegHYabY50fqF9nJh9npWNhvITdkQHeaOqnFXUIwxfiEeUt49Yoa2waRR7a5LdRAP3SVM8hz0KIBT4="


### PR DESCRIPTION
# Goal

Provide a workaround for https://github.com/eduardoboucas/staticman/issues/279.

Since I can't open an issue, I've made this PR instead.  The main point is to use an alternative API instance instead of the official one to avoid unexpected service interruption caused by unnotified updates on the official one.  You may choose either self-hosting your own instance or use an existing one.

- [self-hosting guide from Data Science Blog](https://www.datascienceblog.net/post/other/staticman_comments/)
- use an existing API: see below

P.S. I've authored daattali/beautiful-jekyll#440, which is essentially a port of Minimal Mistake's Staticman integration, but defaulting to @staticmanlab that I've created.

# :construction_worker_man: Staticman configurations with screenshots

:email: Please don't hesitate to ping me on GitHub/GitLab/leave a comment on my blog/send me an email to ask for help.

1. :checkered_flag: Invite @staticmanlab as a collaborator to your repository (by going to your repository Settings page, navigate to the Collaborators tab).  
![send invitation to Staticman Lab](https://git.io/fjZPx)  
Image short link: https://git.io/fjZPx
2. :ballot_box_with_check: Help @staticmanlab accept the invitation by going to

        https://staticman3.herokuapp.com/v3/connect/github/<username>/<repo-name>

    In your case, that's

        https://staticman3.herokuapp.com/v3/connect/github/PGui/pgui.github.io

    ![Staticman Lab invitation accepted](https://camo.githubusercontent.com/fca08dcc33537c78f0b56e934afde4af0605f706/68747470733a2f2f76696e63656e7474616d2e6769746c61622e696f2f706f73742f323031382d31322d31392d7374617469636d616e2d696e7669746174696f6e2d69732d636173652d73656e7369746976652f696e76697465322e706e67)  
    Figure: image showing setup for [my fork of this theme](//git.io/bjsm0)  
    Image short link: https://git.io/fjZXG

    ![Staticman Lab shown as collaborator](https://camo.githubusercontent.com/eb3d86ecf35497912c485fb2d339d9d3cd962197/68747470733a2f2f76696e63656e7474616d2e6769746c61622e696f2f706f73742f323031382d31322d31392d7374617469636d616e2d696e7669746174696f6e2d69732d636173652d73656e7369746976652f696e76697465332e706e67)  
    Figure: @staticmanlab invited to GitHub repo  
    Image short link: https://git.io/fjZXZ

3. :writing_hand: Fill in your `repository` and `branch` in the Staticman section of `_config.yml`.

    ```yml
     # Staticman support 
     staticman: 
       ...
       endpoint   : # I've edited that for you, but feel free to change it to your favorite one.
       ...
    ```

4. :memo: Start commenting.